### PR TITLE
feat: cleanup on graceful shutdown

### DIFF
--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -145,6 +145,12 @@ impl Sisyphus {
         self.task
     }
 
+    /// Wait for the task to change status.
+    /// Errors if the status channel is closed.
+    pub async fn watch_status(&mut self) -> Result<(), watch::error::RecvError> {
+        self.status.changed().await
+    }
+
     /// Return the task's current status
     pub fn status(&self) -> String {
         self.status.borrow().to_string()


### PR DESCRIPTION
To support cleanup on graceful shutdown, I am suggesting the following changes:

- The user is responsible for handling the shutdown signal and returning a `Fall::Shutdown{ task: self}`
- The shutdown signal sender is passed to the user via `spawn`
- The above enables the task to know that the task has stopped working to make the cleanup cleaner( `stop work/return Fall -> cleanup -> abort tokio task`)

Open questions:
- Create newtype for the signal so the implementation type is not leaked to the user API
- Rename Fall to something like Res(ult) and have `Fall::Recoverable` -> `Res::RecoverableError`