### PR TITLE
feat: bootstrap lifecycle function (#3)

### DIFF
--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -145,6 +145,12 @@ impl Sisyphus {
         self.task
     }
 
+    /// Wait for the task to change status.
+    /// Errors if the status channel is closed.
+    pub async fn watch_status(&mut self) -> Result<(), watch::error::RecvError> {
+        self.status.changed().await
+    }
+
     /// Return the task's current status
     pub fn status(&self) -> String {
         self.status.borrow().to_string()

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -399,7 +399,7 @@ pub(crate) mod test {
     }
 
     impl Boulder for RecoverableTask {
-        fn spawn(&mut self, shutdown_tx: mpsc::Sender<()>) -> JoinHandle<Fall>
+        fn spawn(&mut self, _shutdown_tx: mpsc::Sender<()>) -> JoinHandle<Fall>
         where
             Self: 'static + Send + Sync + Sized,
         {
@@ -435,7 +435,7 @@ pub(crate) mod test {
     }
 
     impl Boulder for UnrecoverableTask {
-        fn spawn(&mut self, shutdown: mpsc::Sender<()>) -> JoinHandle<Fall> {
+        fn spawn(&mut self, _shutdown: mpsc::Sender<()>) -> JoinHandle<Fall> {
             tokio::spawn(async move {
                 Fall::Unrecoverable {
                     err: eyre::eyre!("Tis only a scratch"),
@@ -466,7 +466,7 @@ pub(crate) mod test {
     }
 
     impl Boulder for PanicTask {
-        fn spawn(&mut self, shutdown: mpsc::Sender<()>) -> JoinHandle<Fall>
+        fn spawn(&mut self, _shutdown: mpsc::Sender<()>) -> JoinHandle<Fall>
         where
             Self: 'static + Send + Sync + Sized,
         {
@@ -514,7 +514,7 @@ pub(crate) mod test {
 
     #[tokio::test]
     async fn test_shutdown() {
-        let mut handle = ShutdownTask {}.run_until_panic();
+        let handle = ShutdownTask {}.run_until_panic();
         sleep(Duration::from_millis(1200)).await;
         assert_eq!(
             handle.status().to_string(),

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -399,7 +399,7 @@ pub(crate) mod test {
     }
 
     impl Boulder for RecoverableTask {
-        fn spawn(&mut self, _shutdown_tx: mpsc::Sender<()>) -> JoinHandle<Fall>
+        fn spawn(&mut self, shutdown_tx: mpsc::Sender<()>) -> JoinHandle<Fall>
         where
             Self: 'static + Send + Sync + Sized,
         {
@@ -435,7 +435,7 @@ pub(crate) mod test {
     }
 
     impl Boulder for UnrecoverableTask {
-        fn spawn(&mut self, _shutdown: mpsc::Sender<()>) -> JoinHandle<Fall> {
+        fn spawn(&mut self, shutdown: mpsc::Sender<()>) -> JoinHandle<Fall> {
             tokio::spawn(async move {
                 Fall::Unrecoverable {
                     err: eyre::eyre!("Tis only a scratch"),
@@ -466,7 +466,7 @@ pub(crate) mod test {
     }
 
     impl Boulder for PanicTask {
-        fn spawn(&mut self, _shutdown: mpsc::Sender<()>) -> JoinHandle<Fall>
+        fn spawn(&mut self, shutdown: mpsc::Sender<()>) -> JoinHandle<Fall>
         where
             Self: 'static + Send + Sync + Sized,
         {
@@ -505,16 +505,13 @@ pub(crate) mod test {
                         },
                     }
                 }
-                Fall::Recoverable {
-                    err: eyre::eyre!("Shutdown received"),
-                }
             })
         }
     }
 
     #[tokio::test]
     async fn test_shutdown() {
-        let handle = ShutdownTask {}.run_until_panic();
+        let mut handle = ShutdownTask {}.run_until_panic();
         sleep(Duration::from_millis(1200)).await;
         assert_eq!(
             handle.status().to_string(),

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -292,6 +292,8 @@ pub trait Boulder: std::fmt::Display + Sized {
         let restarts_loop_ref = restarts.clone();
 
         let task: JoinHandle<()> = tokio::spawn(async move {
+            tx.send(TaskStatus::Running)
+                .expect("Failed to send task status");
             self.bootstrap(self.first_time(&restarts_loop_ref)).await;
             let handle = self.spawn(shutdown_recv);
             tokio::pin!(handle);

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -419,9 +419,11 @@ pub(crate) mod test {
         let handle = handle.shutdown();
         let result = handle.await;
 
-        assert!(logs_contain("RecoverableTask"));
-        assert!(logs_contain("Restarting task"));
-        assert!(logs_contain("This error was recoverable"));
+        assert!(logs_contain(
+            "error=\"Error 1/1\" error=I only took an arrow to the knee"
+        ));
+        assert!(logs_contain("Task Recovering.."));
+        assert!(logs_contain("Task Restarting ↺"));
         assert!(result.is_ok());
     }
 

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -299,8 +299,8 @@ pub trait Boulder: std::fmt::Display + Sized {
         let restarts_loop_ref = restarts.clone();
         let task: JoinHandle<()> = tokio::spawn(async move {
             let handle = self.spawn(shutdown);
-            // tx.send(TaskStatus::Running)
-            //     .expect("Failed to send task status");
+            tx.send(TaskStatus::Running)
+                .expect("Failed to send task status");
             tokio::pin!(handle);
             loop {
                 select! {

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -6,8 +6,10 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
+    task::{Context, Poll},
 };
 
+use futures::FutureExt;
 use tokio::{
     select,
     sync::{oneshot, watch},
@@ -185,6 +187,17 @@ impl IntoFuture for Sisyphus {
 /// The shutdown signal for the task
 pub struct ShutdownSignal(oneshot::Receiver<()>);
 
+impl Future for ShutdownSignal {
+    type Output = Result<(), oneshot::error::RecvError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.0.poll_unpin(cx) {
+            Poll::Ready(res) => Poll::Ready(res),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
 /// Convenience trait for conerting errors to [`Fall`]
 pub trait ErrExt: std::error::Error + Sized + Send + Sync + 'static {
     /// Convert an error to a recoverable [`Fall`]
@@ -356,12 +369,15 @@ pub trait Boulder: std::fmt::Display + Sized {
                             }
 
                             Ok(Fall::Shutdown{mut task}) => {
-                                let _ = task.cleanup().await;
                                 // We don't check the result of the send
                                 // because we're stopping regardless of
                                 // whether it worked
-                                let _ = tx.send(TaskStatus::Stopped{exceptional: false, err: eyre::eyre!("Shutdown")});
+                                // abort work
                                 handle.abort();
+                                // then  cleanup
+                                let _ = task.cleanup().await;
+                                // then set status to Stopped
+                                let _ = tx.send(TaskStatus::Stopped{exceptional: false, err: eyre::eyre!("Shutdown")});
                                 break;
                             }
 
@@ -392,7 +408,6 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 panic::resume_unwind(p);
                             }
                         };
-
                         // We use a noisy sleep here to nudge tasks off
                         // eachother if they're crashing around the same time
                         utils::noisy_sleep(again.restart_after_ms()).await;

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -316,6 +316,7 @@ pub trait Boulder: std::fmt::Display + Sized {
         let task: JoinHandle<()> = tokio::spawn(async move {
             let res = self.bootstrap(self.first_time(&restarts_loop_ref)).await;
             if let Err(err) = res {
+                let _ = self.cleanup().await;
                 let error_chain = err
                     .chain()
                     .map(|e| e.to_string())

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -334,7 +334,7 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 // We don't check the result of the send
                                 // because we're stopping regardless of
                                 // whether it worked
-                                let _ = tx.send(TaskStatus::Stopped{exceptional: false, err: Arc::new(eyre::eyre!("Shutdown"))});
+                                let _ = tx.send(TaskStatus::Stopped{exceptional, err: Arc::new(err)});
                                 break;
                             }
 

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -64,20 +64,20 @@ pub enum Fall<T> {
 }
 
 /// The current state of a Sisyphus task.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TaskStatus {
     /// Task is starting
     Starting,
     /// Task is running
     Running,
     /// Task is waiting to resume running
-    Recovering(eyre::Report),
+    Recovering(Arc<eyre::Report>),
     /// Task is stopped, and will not resume
     Stopped {
         /// Whether the error is exceptional, or normal lifecycle
         exceptional: bool,
         /// The error that triggered the stop
-        err: eyre::Report,
+        err: Arc<eyre::Report>,
     },
     /// Task has panicked
     Panicked,
@@ -158,13 +158,14 @@ impl Sisyphus {
 
     /// Wait for the task to change status.
     /// Errors if the status channel is closed.
-    pub async fn watch_status(&mut self) -> Result<(), watch::error::RecvError> {
-        self.status.changed().await
+    pub async fn watch_status(&mut self) -> Result<TaskStatus, watch::error::RecvError> {
+        self.status.changed().await?;
+        Ok(self.status.borrow().clone())
     }
 
     /// Return the task's current status
-    pub fn status(&self) -> String {
-        self.status.borrow().to_string()
+    pub fn status(&self) -> TaskStatus {
+        self.status.borrow().clone()
     }
 
     /// The number of times the task has restarted
@@ -325,13 +326,13 @@ pub trait Boulder: std::fmt::Display + Sized {
                 tracing::error!(err = %err, error_chain, task = task_description.as_str(), "Error encountered during bootstrap");
                 let _ = tx.send(TaskStatus::Stopped {
                     exceptional: true,
-                    err,
+                    err: Arc::new(err),
                 });
                 return;
             }
             let handle = self.spawn(shutdown);
-            tx.send(TaskStatus::Running)
-                .expect("Failed to send task status");
+            // tx.send(TaskStatus::Running)
+            //     .expect("Failed to send task status");
             tokio::pin!(handle);
             loop {
                 select! {
@@ -341,7 +342,7 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 // Sisyphus has been dropped, so we can drop this task
                                 let e_string = err.to_string();
                                 let error_chain= err.chain().map(|e| e.to_string()).collect::<Vec<String>>().join(" --> ");
-                                if tx.send(TaskStatus::Recovering(err)).is_err() {
+                                if tx.send(TaskStatus::Recovering(Arc::new(err))).is_err() {
                                     break;
                                 }
                                 task.recover().await;
@@ -365,7 +366,7 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 // We don't check the result of the send
                                 // because we're stopping regardless of
                                 // whether it worked
-                                let _ = tx.send(TaskStatus::Stopped{exceptional, err});
+                                let _ = tx.send(TaskStatus::Stopped{exceptional, err: Arc::new(err) });
                                 break;
                             }
 
@@ -378,7 +379,7 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 // then  cleanup
                                 let _ = task.cleanup().await;
                                 // then set status to Stopped
-                                let _ = tx.send(TaskStatus::Stopped{exceptional: false, err: eyre::eyre!("Shutdown")});
+                                let _ = tx.send(TaskStatus::Stopped{exceptional: false, err: Arc::new(eyre::eyre!("Shutdown"))});
                                 break;
                             }
 
@@ -395,7 +396,7 @@ pub trait Boulder: std::fmt::Display + Sized {
                                     // whether it worked
                                     let status = TaskStatus::Stopped{
                                         exceptional: false,
-                                        err:eyre::eyre!(panic_res.unwrap_err())
+                                        err:Arc::new(eyre::eyre!(panic_res.unwrap_err()))
                                     };
                                     let _ = tx.send(status);
                                     break;


### PR DESCRIPTION
I cleaned up the interface of the trait. You no longer have to mess with self and shutdown signals.

Moreover, the shutdown signal can be invoked either externally or from the task itself.